### PR TITLE
Fix a bug when creating elements

### DIFF
--- a/src/components/ElementCreatorContainer.js
+++ b/src/components/ElementCreatorContainer.js
@@ -170,6 +170,8 @@ class ElementCreatorContainer extends React.Component {
             getElementKind={this.getElementKind.bind(this)}
             setElementKind={this.setElementKind.bind(this)}
             handleChange={this.handleElementCreatorChange.bind(this)}
+            isDraggable={this.vars.isDraggable}
+            isDrawable={this.vars.isDrawable}
           />
         );
       }

--- a/src/components/ElementKindSelector.js
+++ b/src/components/ElementKindSelector.js
@@ -40,6 +40,7 @@ const ElementKindSelector = props => {
         <br />
         <Toggle
           label="draggable"
+          defaultToggled={props.isDraggable}
           onToggle={(e, newValue) => {
             props.handleChange('draggable', e, newValue);
           }}
@@ -47,6 +48,7 @@ const ElementKindSelector = props => {
         <br />
         <Toggle
           label="drawable"
+          defaultToggled={props.isDrawable}
           disabled={showIsDrawable(props.getElementKind())}
           onToggle={(e, newValue) => {
             props.handleChange('drawable', e, newValue);


### PR DESCRIPTION
bug recurrence steps:
1. choose an element type. for example: standard; then switch "isDraggable" to be true.
2. Press "next" button and then "back" to change the element type. ("isDraggable" is shown false now)
3. Choose the images and create the element. 
Finding that isDraggable is true in firebase (which is shown false when rechoosing the type).

...

Fix this bug, every time the user uses "back" button to re-choose the element type, show the properties that the user set last time.
